### PR TITLE
expose set_charge method and fix spec of TDA in orca inputs

### DIFF
--- a/src/calcflow/core.py
+++ b/src/calcflow/core.py
@@ -149,3 +149,21 @@ class CalculationInput(ABC):
         # The __post_init__ method will handle warnings related to spin multiplicity mismatch.
         logger.debug(f"Setting unrestricted to: {True}")
         return replace(self, unrestricted=True)
+
+    def set_charge(self: T_CalcInput, charge: int) -> T_CalcInput:
+        """
+        Set the molecular charge.
+
+        Args:
+            charge (int): The new molecular charge.
+
+        Returns:
+            T_CalcInput: A new instance of the CalculationInput subclass with the charge updated.
+
+        Raises:
+            ValidationError: If charge is not an integer.
+        """
+        if not isinstance(charge, int):
+            raise ValidationError("Charge must be an integer.")
+        logger.debug(f"Setting charge to: {charge}")
+        return replace(self, charge=charge)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,6 +123,23 @@ def test_post_init_warnings(caplog: LogCaptureFixture) -> None:
     assert "unrestricted calculation with a singlet spin multiplicity" in caplog.text
     caplog.clear()
 
+def test_set_charge(base_input: SimpleInput) -> None:
+    """Test the set_charge method."""
+    assert base_input.charge == 0  # Default from fixture
+
+    # Set new valid charge
+    charged_input = base_input.set_charge(-1)
+    assert charged_input.charge == -1
+    assert charged_input is not base_input  # Ensure immutability
+    assert charged_input.spin_multiplicity == base_input.spin_multiplicity # Other fields unchanged
+
+    # Test invalid charge type
+    with pytest.raises(ValidationError, match="Charge must be an integer"):
+        base_input.set_charge("invalid_charge") # type: ignore
+
+    with pytest.raises(ValidationError, match="Charge must be an integer"):
+        base_input.set_charge(1.5) # type: ignore
+
 def test_export_input_file(base_input: SimpleInput) -> None:
     """Test the basic export_input_file implementation."""
     geom = Geometry(num_atoms=2, comment="", atoms=[("O", (0, 0, 0)), ("H", (0, 0, 1))])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fluent method to set molecular charge with validation and immutability.

- **Refactor**
  - Updated TDDFT configuration to use a boolean flag for TDA instead of a method string selector in Orca input handling.

- **Tests**
  - Added tests for the new charge setter method.
  - Updated Orca input tests to reflect the new TDDFT configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->