### PR TITLE
examples of use in readme, copy method on inputs, allow changing charge for second mom job

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ TransitionDMMulliken(
 
 See [scripts/create-parse-qchem.py](scripts/create-parse-qchem.py) for more examples or to play with outputs used for tests (stored in [data/calculations/examples/qchem/](data/calculations/examples/qchem/))
 
+### Which versions of QChem do you support?
+
+It's tested on 6.2 and 5.4. Good news is that I'm intending to make it easy to adjust for version-specific printing. For example,
+
+```txt
+QChem 5.4. prints final SCF energy as
+SCF   energy in the final basis set =      -75.3184602363
+while 6.2. prints it as
+SCF   energy =   -75.32080770
+
+p.s. nevermind the difference in energy, 5.4. mistakenly prints SCF energy same as Total energy, which includes solvation terms
+```
+
+which is why the [calcflow/parsers/qchem/blocks/scf.py](src/calcflow/parsers/qchem/blocks/scf.py) block defines different patterns for different versions:
+
+```py
+PatternDefinition(field_name="scf_energy", required=True, description="Final SCF energy value",
+versioned_patterns=[
+        (re.compile(r"^\s*SCF\s+energy\s*=\s*(-?\d+\.\d+)"), "6.2", lambda m: float(m.group(1))),
+        (re.compile(r"^\s*SCF\s+energy in the final basis set\s*=\s*(-?\d+\.\d+)"), "5.4", lambda m: float(m.group(1))),
+    ],
+),
+```
+
 ## Contributing
 
 Direct, effective contributions are welcome. Fork, modify, test, and pull request. Adhere to existing quality standards.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,125 @@
 [![codecov](https://codecov.io/gh/batistagroup/calcflow/graph/badge.svg?token=bO5X75J8li)](https://codecov.io/gh/batistagroup/calcflow)
 ![codequal](https://github.com/batistagroup/calcflow/actions/workflows/quality.yml/badge.svg)
 
-A Python package to simplify preparing and parsing quantum chemistry calculations, with no external dependencies (is true now, will be true forever). Provides a clean, Pythonic API for interacting with QChem, ORCA, and potentially other quantum chemistry software.
+**CalcFlow: Quantum Chemistry Calculation I/O. Done Right.**
 
-## Features
+`CalcFlow` provides a robust, Pythonic interface for preparing inputs and parsing outputs for quantum chemistry software like Q-Chem and ORCA. It has **zero external dependencies** and is built for clarity and reliability. Get your calculations set up and results processed without the usual boilerplate.
 
-- **No Dependencies**: Built entirely on Python standard library
-- **Immutable Objects**: Dataclass-based with a fluent API for transparent, thread-safe state changes
-- **Strongly Typed**: Comprehensive type hints and validation for safer code
-- **Comprehensive Validation**: Prevent errors before they happen with rigorous validation of inputs
-- **Program-Agnostic API**: Abstract away program-specific syntax with a consistent interface
-- **Extensible Design**: Abstract base classes make it easy to add support for additional programs
+WARNING: Package is in pre-release alpha stage. May introduce backwards-incompatible changes. Contributions & suggestions & advice are welcome.
+
+## Key Features
+
+what you care about:
+
+- **Zero Dependencies**: is true now, will be true forever. Integrate into any project without worrying about whether it matches your numpy or rdkit version.
+- **Intuitive Pythonic Interface**: specify calculation parameters how you think about them and calcflow will handle the translation into what QChem or ORCA expects.
+- **Proactive Input Validation**: Minimizes runtime errors by rigorously validating all calculation parameters against both general and program-specific constraints.
+- **Comprehensive Parsing**: stop wasting time on extracting data you need from a txt out file and start doing meaningful work (analysis).
+
+what's nice under the hood:
+
+- **Immutable & Fluent API**: ensures data integrity and predictable state transitions via `frozen` dataclasses and an expressive, chainable API.
+- **Fully Type Annotated**: code is more robust and easier to understand.
+- **Extensible Core Architecture**: designed with clear abstract base classes, simplifying the integration of support for additional quantum chemistry programs.
+- **Assured Reliability via Comprehensive Testing**: so you don't have to worry if the parser is working correctly.
+
+## Quick Start: Q-Chem TDDFT Example
+
+Set up a Q-Chem tddft calculation for a water molecule with SMD solvation:
+
+```python
+from calcflow.geometry.static import Geometry
+from calcflow.inputs.qchem import QchemInput
+
+# 1. Define Molecular Geometry
+atoms = [
+    ("O", (0.000000, 0.000000, 0.117300)),
+    ("H", (0.000000, 0.757200, -0.469200)),
+    ("H", (0.000000, -0.757200, -0.469200)),
+]
+water_molecule = Geometry(atoms=atoms, comment="Water molecule for Q-Chem SP")
+# or load from xyz file
+water_molecule = Geometry.from_xyz_file(data_path / "1h2o.xyz")
+
+# 2. Configure Q-Chem Calculation Input
+base_job = QchemInput(
+    charge=0, spin_multiplicity=1, task="energy", 
+    level_of_theory="wB97X-D3", basis_set="def2-tzvp", n_cores=16,
+    run_tddft=True, tddft_nroots=10, tddft_singlets=True, tddft_triplets=False
+)
+
+# Uses a fluent API for modifications.
+qchem_job = base_job.set_solvation(model="smd", solvent="water") 
+
+# 3. Export the Input File Content
+with open("h2o_tddft.in", "w") as f:
+    f.write(qchem_job.export_input_file(water_molecule))
+```
+
+Want to create another input file for a tddft with triplets or with state analysis? ezy.
+
+```python
+job2 = qchem_job.set_tddft(nroots=10, singlets=True, triplets=True, state_analysis=True)
+with open("h2o_tddft.in", "w") as f:
+    f.write(job2.export_input_file(water_molecule))
+```
+
+what about getting an O K-Edge XAS spectrum with an element-specific basis?
+
+```python
+job3 = (
+    qchem_job.set_tddft(nroots=10, singlets=True, triplets=False, state_analysis=True)
+    .set_basis({"H": "pc-2", "O": "pcX-2"})
+    .set_reduced_excitation_space(solute_orbitals=[1])
+)
+with open("h2o_xas.in", "w") as f:
+    f.write(job3.export_input_file(water_molecule))
+```
+
+
+## Parsing Q-Chem Output Files
+
+Once your Q-Chem calculation is complete, use `CalcFlow` parsers. Example for a single point energy calculation:
+
+```python
+from calcflow.parsers.qchem import parse_qchem_sp_output # Specific parser for Q-Chem SP
+
+# Path to your Q-Chem output file
+output_file_path = "h2o_qchem_sp.out" # Replace with your actual file path
+
+try:
+    with open(output_file_path, "r") as f:
+        output_content = f.read()
+
+    # Parse the content
+    parsed_data = parse_qchem_sp_output(output_content)
+
+    # Access extracted information
+    if parsed_data.success:
+        print(f"Q-Chem calculation successful!")
+        print(f"Final SCF Energy: {parsed_data.final_energy} Eh")
+        if parsed_data.multipole_moments:
+            print(f"Dipole Moment (Debye): {parsed_data.multipole_moments.dipole_moment_debye}")
+        if parsed_data.smd: # If SMD solvation was used
+            print(f"SMD Solvation Energy: {parsed_data.smd.smd_energy_solvent} Eh")
+            print(f"Total Energy with SMD: {parsed_data.smd.total_energy_with_solvent} Eh")
+    else:
+        print(f"Q-Chem calculation failed or did not complete.")
+        if parsed_data.errors: # Check for errors attribute
+            print(f"Errors: {', '.join(parsed_data.errors)}")
+
+except FileNotFoundError:
+    print(f"Error: Output file '{output_file_path}' not found.")
+except Exception as e:
+    print(f"An error occurred during parsing: {e}")
+```
+*Note: The exact parser module (e.g., `parse_qchem_tddft_output`, `parse_qchem_mom_output`) and the attributes of `parsed_data` will vary based on the Q-Chem calculation type. Consult the `calcflow.parsers` documentation for details.*
+
+## Contributing
+
+Direct, effective contributions are welcome. Fork, modify, test, and pull request. Adhere to existing quality standards.
+
+## License
+
+MIT. Pure and simple.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **CalcFlow: Quantum Chemistry Calculation I/O. Done Right.**
 
-`CalcFlow` provides a robust, Pythonic interface for preparing inputs and parsing outputs for quantum chemistry software like Q-Chem and ORCA. It has **zero external dependencies** and is built for clarity and reliability. Get your calculations set up and results processed without the usual boilerplate.
+CalcFlow provides a robust, Pythonic interface for preparing inputs and parsing outputs for quantum chemistry software like Q-Chem and ORCA. It has **zero external dependencies** and is built for clarity and reliability. Get your calculations set up and results processed without the usual boilerplate.
 
 WARNING: Package is in pre-release alpha stage. May introduce backwards-incompatible changes. Contributions & suggestions & advice are welcome.
 
@@ -171,7 +171,7 @@ TransitionDMMulliken(
     sum_abs_trans_charges_qta=0.002226, sum_sq_trans_charges_qt2=2e-06)
 ```
 
-See [scripts/create-parse-qchem.py](scripts/create-parse-qchem.py) for more examples or to play with outputs used for tests (stored in [](data/calculations/examples/qchem/))
+See [scripts/create-parse-qchem.py](scripts/create-parse-qchem.py) for more examples or to play with outputs used for tests (stored in [data/calculations/examples/qchem/](data/calculations/examples/qchem/))
 
 ## Contributing
 

--- a/scripts/create-parse-qchem.py
+++ b/scripts/create-parse-qchem.py
@@ -37,11 +37,11 @@ run = {
     "tddft-create": False,
     "tddft-parse": False,
     "mom-parse": False,
-    "mom-xas-parse": False,
+    "mom-xas-parse": True,
     "sp-parse-5.4": False,
     "tddft-uks-parse-5.4": False,
     "mom-sp-parse-5.4": False,
-    "mom-xas-parse-5.4": True,
+    "mom-xas-parse-5.4": False,
 }
 
 if run["sp-create"]:
@@ -124,6 +124,7 @@ if run["mom-xas-parse"]:
     print(mom_pc2.job2)
     print(mom_pc2.job2.scf)
     print(mom_pc2.job2.tddft)
+    breakpoint()
 
 if run["sp-parse-5.4"]:
     sp_sto = parse_qchem_sp_output((clc_54_folder / "sp-sto-smd.out").read_text())

--- a/src/calcflow/inputs/qchem.py
+++ b/src/calcflow/inputs/qchem.py
@@ -306,7 +306,7 @@ class QchemInput(CalculationInput):
 
         # For MOM targeting ground state or excited states, we currently only support
         # closed-shell singlet reference states for determining occupations.
-        if self.charge != 0 or self.spin_multiplicity != 1:
+        if self.mom_transition is not None and self.charge != 0 or self.spin_multiplicity != 1:
             raise NotSupportedError(
                 "MOM occupation determination currently only supports closed-shell singlet reference states. "
                 f"Got charge={self.charge}, multiplicity={self.spin_multiplicity}."

--- a/src/calcflow/inputs/qchem.py
+++ b/src/calcflow/inputs/qchem.py
@@ -73,7 +73,7 @@ class QchemInput(CalculationInput):
     mom_alpha_occ: str | None = None
     mom_beta_occ: str | None = None
     mom_transition: str | None = None  # Stores symbolic transition if using that mode
-    mom_job2_charge: int | None = None # Charge for the second job in a MOM calculation
+    mom_job2_charge: int | None = None  # Charge for the second job in a MOM calculation
 
     implicit_solvation_model: QCHEM_ALLOWED_SOLVATION_MODELS | None = None
     solvent: str | None = None
@@ -736,7 +736,9 @@ class QchemInput(CalculationInput):
         if self.mom_job2_charge is not None:
             # If a specific charge is set for job 2, generate a full $molecule block
             logger.info(f"Generating $molecule block for MOM job 2 with charge: {self.mom_job2_charge}")
-            second_job_molecule_block = self._get_molecule_block(geometry.get_coordinate_block(), charge_override=self.mom_job2_charge)
+            second_job_molecule_block = self._get_molecule_block(
+                geometry.get_coordinate_block(), charge_override=self.mom_job2_charge
+            )
         else:
             # Default behavior: read geometry from the first job
             second_job_molecule_block = "$molecule\n    read\n$end"
@@ -779,7 +781,9 @@ class QchemInput(CalculationInput):
             raise ConfigurationError(
                 "MOM must be enabled (run_mom=True) via enable_mom() before setting a specific charge for the second MOM job."
             )
-        logger.info(f"Setting charge for second MOM job to: {charge}. This will affect the $molecule block and electron count for job 2.")
+        logger.info(
+            f"Setting charge for second MOM job to: {charge}. This will affect the $molecule block and electron count for job 2."
+        )
         return replace(self, mom_job2_charge=charge)
 
 

--- a/src/calcflow/inputs/qchem.py
+++ b/src/calcflow/inputs/qchem.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import ClassVar, Literal, TypeVar, cast, get_args
 
@@ -113,6 +114,14 @@ class QchemInput(CalculationInput):
             raise ValidationError(
                 f"Solvation model '{self.implicit_solvation_model}' not recognized. Allowed: {get_args(QCHEM_ALLOWED_SOLVATION_MODELS)}"
             )
+
+    def copy(self: T_QchemInput) -> T_QchemInput:
+        """Create a deep copy of the QchemInput instance.
+
+        Returns:
+            A new QchemInput instance with the same parameters.
+        """
+        return deepcopy(self)
 
     def enable_mom(self: T_QchemInput, method: str = "IMOM") -> T_QchemInput:
         """Enable MOM calculation with specified method.

--- a/tests/inputs/qchem/test_input_qchem_init.py
+++ b/tests/inputs/qchem/test_input_qchem_init.py
@@ -146,21 +146,21 @@ def test_qchem_input_post_init_trnss_without_tddft() -> None:
             basis_set="sto-3g",
             reduced_excitation_space=True,
             run_tddft=False,  # Explicitly set to False
-            solute_orbitals=[1, 2],  # Provide valid orbitals to isolate the TDDFT dependency check
+            initial_orbitals=[1, 2],  # Provide valid orbitals to isolate the TDDFT dependency check
         )
 
 
 @pytest.mark.parametrize(
-    "solute_orbitals, expected_error_match",
+    "initial_orbitals, expected_error_match",
     [
-        ([], "The solute_orbitals list cannot be empty for reduced excitation space."),
-        ([1, 0], "All solute_orbitals must be positive integers."),
-        ([1, -2], "All solute_orbitals must be positive integers."),
-        ([1.5], "All solute_orbitals must be positive integers."),  # Test non-integer
+        ([], "The initial_orbitals list cannot be empty for reduced excitation space."),
+        ([1, 0], "All initial_orbitals must be positive integers."),
+        ([1, -2], "All initial_orbitals must be positive integers."),
+        ([1.5], "All initial_orbitals must be positive integers."),  # Test non-integer
     ],
 )
-def test_qchem_input_post_init_trnss_invalid_solute_orbitals(solute_orbitals, expected_error_match) -> None:
-    """Test validation error if reduced_excitation_space is True but solute_orbitals are invalid."""
+def test_qchem_input_post_init_trnss_invalid_solute_orbitals(initial_orbitals, expected_error_match) -> None:
+    """Test validation error if reduced_excitation_space is True but initial_orbitals are invalid."""
     # TDDFT must be enabled for TRNSS check to be reached
     with pytest.raises(ValidationError, match=expected_error_match):
         QchemInput(
@@ -169,10 +169,10 @@ def test_qchem_input_post_init_trnss_invalid_solute_orbitals(solute_orbitals, ex
             task="energy",
             level_of_theory="hf",
             basis_set="sto-3g",
-            run_tddft=True,  # TDDFT enabled to reach solute_orbitals validation
+            run_tddft=True,  # TDDFT enabled to reach initial_orbitals validation
             tddft_nroots=5,
             reduced_excitation_space=True,
-            solute_orbitals=solute_orbitals,
+            initial_orbitals=initial_orbitals,
         )
 
 
@@ -187,7 +187,7 @@ def test_qchem_input_copy_method(default_qchem_input: QchemInput) -> None:
         run_tddft=True,
         tddft_nroots=3,
         reduced_excitation_space=True,
-        solute_orbitals=[10, 20, 30],
+        initial_orbitals=[10, 20, 30],
         basis_set={"C": "6-31g*", "H": "sto-3g"},  # Use a dict basis for deepcopy check
     )
 
@@ -201,14 +201,14 @@ def test_qchem_input_copy_method(default_qchem_input: QchemInput) -> None:
 
     # 3. Test deep copy behavior for mutable attributes
 
-    # Test with solute_orbitals (list)
-    assert copied_input.solute_orbitals is not None
-    assert original_input.solute_orbitals is not None
-    copied_input.solute_orbitals.append(40)
-    assert original_input.solute_orbitals == [10, 20, 30], (
-        "Modifying solute_orbitals in copied input should not affect original."
+    # Test with initial_orbitals (list)
+    assert copied_input.initial_orbitals is not None
+    assert original_input.initial_orbitals is not None
+    copied_input.initial_orbitals.append(40)
+    assert original_input.initial_orbitals == [10, 20, 30], (
+        "Modifying initial_orbitals in copied input should not affect original."
     )
-    assert copied_input.solute_orbitals == [10, 20, 30, 40]
+    assert copied_input.initial_orbitals == [10, 20, 30, 40]
 
     # Test with basis_set (dict)
     assert isinstance(copied_input.basis_set, dict)

--- a/tests/inputs/qchem/test_input_qchem_mom.py
+++ b/tests/inputs/qchem/test_input_qchem_mom.py
@@ -426,6 +426,7 @@ def test_set_mom_ground_state_before_enable(default_qchem_input: QchemInput) -> 
     ):
         default_qchem_input.set_mom_ground_state()
 
+
 # fmt:off
 @pytest.mark.parametrize(
     "geometry_elements_coords, charge, multiplicity, expected_alpha, expected_beta, expected_error, error_match",

--- a/tests/inputs/qchem/test_input_qchem_mom.py
+++ b/tests/inputs/qchem/test_input_qchem_mom.py
@@ -129,14 +129,14 @@ def test_generate_occupied_block_non_singlet(mom_enabled_input: QchemInput, h2o_
     inp_charged = replace(mom_enabled_input, charge=1, unrestricted=True).set_mom_transition("HOMO->LUMO")
     with pytest.raises(
         NotSupportedError,
-        match="MOM occupation determination currently only supports closed-shell singlet reference states",
+        match="MOM occupation determination via symbolic transition or 'GROUND_STATE' marker currently only supports a closed-shell singlet reference state for the job where occupations are determined.",
     ):
         inp_charged._generate_occupied_block(h2o_geometry)
 
     inp_triplet = replace(mom_enabled_input, spin_multiplicity=3, unrestricted=True).set_mom_transition("HOMO->LUMO")
     with pytest.raises(
         NotSupportedError,
-        match="MOM occupation determination currently only supports closed-shell singlet reference states",
+        match="MOM occupation determination via symbolic transition or 'GROUND_STATE' marker currently only supports a closed-shell singlet reference state for the job where occupations are determined.",
     ):
         inp_triplet._generate_occupied_block(h2o_geometry)
 
@@ -426,7 +426,7 @@ def test_set_mom_ground_state_before_enable(default_qchem_input: QchemInput) -> 
     ):
         default_qchem_input.set_mom_ground_state()
 
-
+# fmt:off
 @pytest.mark.parametrize(
     "geometry_elements_coords, charge, multiplicity, expected_alpha, expected_beta, expected_error, error_match",
     [
@@ -434,59 +434,19 @@ def test_set_mom_ground_state_before_enable(default_qchem_input: QchemInput) -> 
         ((["O", "H", "H"], [[0, 0, 0], [0, 0, 1], [0, 1, 0]]), 0, 1, "1:5", "1:5", None, None),  # H2O, 10e-
         ((["He"], [[0, 0, 0]]), 0, 1, "1", "1", None, None),  # He, 2e-
         # Invalid system: non-closed-shell singlet for _generate_occupied_block check
-        (
-            (["O", "H", "H"], [[0, 0, 0], [0, 0, 1], [0, 1, 0]]),
-            1,
-            1,
-            None,
-            None,
-            NotSupportedError,
-            "MOM occupation determination currently only supports closed-shell singlet reference states",
-        ),
-        (
-            (["O", "H", "H"], [[0, 0, 0], [0, 0, 1], [0, 1, 0]]),
-            0,
-            3,
-            None,
-            None,
-            NotSupportedError,
-            "MOM occupation determination currently only supports closed-shell singlet reference states",
-        ),
-        # Invalid system: odd total electrons for GROUND_STATE processing (QchemInput charge=0, mult=1)
-        (
-            (["Li"], [[0, 0, 0]]),
-            0,
-            1,
-            None,
-            None,
-            ConfigurationError,
-            "Expected an even number of total electrons",
-        ),  # Li (Z=3), total_e = 3.
+        ((["O", "H", "H"], [[0, 0, 0], [0, 0, 1], [0, 1, 0]]), 1, 1, None, None, NotSupportedError, "MOM occupation determination via symbolic transition or 'GROUND_STATE' marker currently only supports a closed-shell singlet reference state for the job where occupations are determined."),
+        ((["O", "H", "H"], [[0, 0, 0], [0, 0, 1], [0, 1, 0]]), 0, 3, None, None, NotSupportedError, "MOM occupation determination via symbolic transition or 'GROUND_STATE' marker currently only supports a closed-shell singlet reference state for the job where occupations are determined."),
+        # Invalid system: odd total electrons for GROUND_STATE processing (QchemInput charge=0, mult=1)   # Li (Z=3), total_e = 3.
+        ((["Li"], [[0, 0, 0]]), 0, 1, None, None, ConfigurationError, "Expected an even number of total electrons"),
         # Corrected test for QchemInput(charge=1) for a system that would otherwise have 0 electrons.
-        # This should be caught by the initial NotSupportedError due to QchemInput.charge != 0.
-        (
-            (["H"], [[0, 0, 0]]),
-            1,
-            1,
-            None,
-            None,
-            NotSupportedError,
-            "MOM occupation determination currently only supports closed-shell singlet reference states",
-        ),  # H(Z=1), QchemInput(charge=1). total_e = 0.
-        # New test for insufficient occupied orbitals (QchemInput charge=0, mult=1, but 0 total electrons from geometry)
-        (
-            ([], []),
-            0,
-            1,
-            None,
-            None,
-            ConfigurationError,
-            "System with 0 electrons .* insufficient occupied orbitals for 'GROUND_STATE' MOM",
-        ),  # No atoms -> total_nuclear_charge=0. total_e = 0.
+        # This should be caught by the initial NotSupportedError due to QchemInput.charge != 0. # H(Z=1), QchemInput(charge=1). total_e = 0.
+        ((["H"], [[0, 0, 0]]), 1, 1, None, None, NotSupportedError, "MOM occupation determination via symbolic transition or 'GROUND_STATE' marker currently only supports a closed-shell singlet reference state for the job where occupations are determined."),
+        # New test for insufficient occupied orbitals (QchemInput charge=0, mult=1, but 0 total electrons from geometry).   # No atoms -> total_nuclear_charge=0. total_e = 0.
+        (([], []), 0, 1, None, None, ConfigurationError, "System with 0 electrons .* insufficient occupied orbitals for 'GROUND_STATE' MOM"),
         # N atom (total_nuclear_charge=7) QchemInput(charge=0, mult=1) -> 7e-. Expect odd electron error.
         ((["N"], [[0, 0, 0]]), 0, 1, None, None, ConfigurationError, "Expected an even number of total electrons"),
     ],
-)
+) # fmt:on
 def test_generate_occupied_block_mom_ground_state(
     unrestricted_input: QchemInput,
     geometry_elements_coords: tuple[list[str], list[list[float]]],

--- a/tests/inputs/qchem/test_input_qchem_setters.py
+++ b/tests/inputs/qchem/test_input_qchem_setters.py
@@ -99,7 +99,7 @@ def test_set_basis_dict(default_qchem_input: QchemInput) -> None:
 
 
 @pytest.mark.parametrize(
-    "solute_orbitals, expected_orbitals, expected_error",
+    "initial_orbitals, expected_orbitals, expected_error",
     [
         ([3, 1, 2, 3], [1, 2, 3], None),
         ([], None, ValidationError),
@@ -107,22 +107,22 @@ def test_set_basis_dict(default_qchem_input: QchemInput) -> None:
     ],
 )
 def test_set_reduced_excitation_space(
-    default_qchem_input: QchemInput, solute_orbitals, expected_orbitals, expected_error
+    default_qchem_input: QchemInput, initial_orbitals, expected_orbitals, expected_error
 ) -> None:
     """Test configuring reduced excitation space for TDDFT."""
 
     # Test case where TDDFT is NOT enabled first (should raise ConfigurationError)
     with pytest.raises(ConfigurationError, match="requires TDDFT"):
-        default_qchem_input.set_reduced_excitation_space(solute_orbitals=[1])  # Use a dummy list
+        default_qchem_input.set_reduced_excitation_space(initial_orbitals=[1])  # Use a dummy list
 
     # Enable TDDFT first
     tddft_input = default_qchem_input.set_tddft(nroots=5)
 
     if expected_error:
         with pytest.raises(expected_error):
-            tddft_input.set_reduced_excitation_space(solute_orbitals=solute_orbitals)
+            tddft_input.set_reduced_excitation_space(initial_orbitals=initial_orbitals)
     else:
-        inp = tddft_input.set_reduced_excitation_space(solute_orbitals=solute_orbitals)
+        inp = tddft_input.set_reduced_excitation_space(initial_orbitals=initial_orbitals)
         assert inp.reduced_excitation_space is True
-        assert inp.solute_orbitals == expected_orbitals
+        assert inp.initial_orbitals == expected_orbitals
         assert inp is not tddft_input  # Ensure immutability

--- a/tests/inputs/qchem/test_input_qchem_xas.py
+++ b/tests/inputs/qchem/test_input_qchem_xas.py
@@ -22,48 +22,48 @@ def test_set_reduced_excitation_space_valid(default_qchem_input: QchemInput) -> 
     orbitals = [10, 8, 12, 8]  # Unsorted, with duplicates
     expected_orbitals = [8, 10, 12]
 
-    inp_reduced = inp_tddft.set_reduced_excitation_space(solute_orbitals=orbitals)
+    inp_reduced = inp_tddft.set_reduced_excitation_space(initial_orbitals=orbitals)
 
     assert inp_reduced.run_tddft
     assert inp_reduced.reduced_excitation_space
-    assert inp_reduced.solute_orbitals == expected_orbitals
+    assert inp_reduced.initial_orbitals == expected_orbitals
     assert inp_reduced is not inp_tddft  # Immutability
 
 
 def test_set_reduced_excitation_space_tddft_not_enabled(default_qchem_input: QchemInput) -> None:
     """Test error if setting reduced excitation space before TDDFT is enabled."""
     with pytest.raises(ConfigurationError, match="Reduced excitation space .TRNSS. requires TDDFT to be enabled"):
-        default_qchem_input.set_reduced_excitation_space(solute_orbitals=[1, 2, 3])
+        default_qchem_input.set_reduced_excitation_space(initial_orbitals=[1, 2, 3])
 
 
 def test_set_reduced_excitation_space_empty_orbitals(default_qchem_input: QchemInput) -> None:
-    """Test error if solute_orbitals list is empty."""
+    """Test error if initial_orbitals list is empty."""
     inp_tddft = default_qchem_input.set_tddft(nroots=3)
-    with pytest.raises(ValidationError, match="The solute_orbitals list cannot be empty"):
-        inp_tddft.set_reduced_excitation_space(solute_orbitals=[])
+    with pytest.raises(ValidationError, match="The initial_orbitals list cannot be empty"):
+        inp_tddft.set_reduced_excitation_space(initial_orbitals=[])
 
 
 @pytest.mark.parametrize(
     "invalid_orbitals, error_msg",
     [
-        ([1, 0, 2], "All solute_orbitals must be positive integers."),
-        ([1, -5, 2], "All solute_orbitals must be positive integers."),
-        ([1, 2.5, 3], "All solute_orbitals must be positive integers."),
-        (["a", 2, 3], "All solute_orbitals must be positive integers."),
+        ([1, 0, 2], "All initial_orbitals must be positive integers."),
+        ([1, -5, 2], "All initial_orbitals must be positive integers."),
+        ([1, 2.5, 3], "All initial_orbitals must be positive integers."),
+        (["a", 2, 3], "All initial_orbitals must be positive integers."),
     ],
 )
 def test_set_reduced_excitation_space_invalid_orbital_values(
     default_qchem_input: QchemInput, invalid_orbitals: list, error_msg: str
 ) -> None:
-    """Test error if solute_orbitals list contains non-positive or non-integer values."""
+    """Test error if initial_orbitals list contains non-positive or non-integer values."""
     inp_tddft = default_qchem_input.set_tddft(nroots=3)
     with pytest.raises(ValidationError, match=error_msg):
-        inp_tddft.set_reduced_excitation_space(solute_orbitals=invalid_orbitals)
+        inp_tddft.set_reduced_excitation_space(initial_orbitals=invalid_orbitals)
 
 
 def test_get_rem_block_tddft_reduced_excitation(helpers, default_qchem_input: QchemInput) -> None:
     """Test $rem block with TDDFT and reduced excitation space."""
-    inp = default_qchem_input.set_tddft(nroots=5).set_reduced_excitation_space(solute_orbitals=[8, 10, 11])
+    inp = default_qchem_input.set_tddft(nroots=5).set_reduced_excitation_space(initial_orbitals=[8, 10, 11])
 
     expected_rem_dict = {
         # Base from default_qchem_input
@@ -97,7 +97,7 @@ def test_get_rem_block_tddft_reduced_excitation(helpers, default_qchem_input: Qc
 
 def test_get_solute_block_active(default_qchem_input: QchemInput) -> None:
     """Test $solute block generation when TRNSS is active."""
-    inp = default_qchem_input.set_tddft(nroots=3).set_reduced_excitation_space(solute_orbitals=[7, 8, 9])
+    inp = default_qchem_input.set_tddft(nroots=3).set_reduced_excitation_space(initial_orbitals=[7, 8, 9])
     expected_block = """$solute
 7 8 9
 $end"""
@@ -117,7 +117,7 @@ def test_export_input_file_tddft_reduced_excitation(
     """Test exporting an input file with TDDFT and reduced excitation space."""
     inp = (
         default_qchem_input.set_tddft(nroots=3)
-        .set_reduced_excitation_space(solute_orbitals=[4, 5])
+        .set_reduced_excitation_space(initial_orbitals=[4, 5])
         .set_basis("def2-svp")  # Use a slightly more realistic basis
     )
 
@@ -173,7 +173,7 @@ def test_export_input_file_mom_tddft_reduced_excitation(
         unrestricted_input.enable_mom()
         .set_mom_transition("HOMO->LUMO")  # Sets up MOM for H2O (5 alpha, 5 beta)
         .set_tddft(nroots=2)  # Enable TDDFT for the second job
-        .set_reduced_excitation_space(solute_orbitals=[4, 5])  # Reduce excitation space for TDDFT
+        .set_reduced_excitation_space(initial_orbitals=[4, 5])  # Reduce excitation space for TDDFT
         .set_basis("def2-tzvp")  # Use a different basis for clarity
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify a separate charge for the second job in MOM (Maximum Overlap Method) calculations.

- **Improvements**
  - Renamed the "solute_orbitals" parameter to "initial_orbitals" for greater clarity throughout the interface and documentation.
  - Enhanced the README with a comprehensive user guide, detailed examples, and clearer explanations of key features and usage scenarios.

- **Bug Fixes**
  - Improved error messages for unsupported MOM occupation determination scenarios.

- **Tests**
  - Updated tests to reflect the renaming to "initial_orbitals" and added tests for the new copy functionality and deep copying behavior.

- **Documentation**
  - Expanded and restructured the README for better usability, including new sections on features, quick start, advanced usage, and contributing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->