### PR TITLE
enh: add setter for orca freq that can be run w/ other jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ where `.set_software` dictates which modules/temp variables will be printed, and
 
 Direct, effective contributions are welcome. Fork, modify, test, and pull request. Adhere to existing quality standards.
 
+## Related Works
+
+> How is it different from [QCEngine](https://github.com/MolSSI/QCEngine)?
+
+- QCEngine requires [QCElemental](https://github.com/MolSSI/QCElemental), a dep that is supposed to give you constants and periodic table, but for some reason requires numpy
+- afaict, it also tries to solve a much more difficult and much less relevant problem - automating execution of QC calculations. I don't see how one could anticipate all possible variations in configs of internal clusters. Most importantly, I don't see it as a main problem.
+
+> How is it different from qc suite ([qcio](https://github.com/coltonbh/qcio), [qccodec](https://github.com/coltonbh/qccodec), [qcop](https://github.com/coltonbh/qcop)) by coltonbh?
+
+honestly, qc suite is great and as of now has greater variety of supported QC software and tasks. unfortunately, as is, qcio depends on numpy and qcio/qccodec (which is a direct alternative to calcflow) seem to be too geared for automation with BigChem, which might be a plus for some, but might be too much for people who don't want/need to change their routine and just need easy input prep and output parsing
+
 ## License
 
 MIT. Pure and simple.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CalcFlow
+# CalcFlow: Quantum Chemistry Calculation I/O Done Right
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
@@ -8,11 +8,10 @@
 [![codecov](https://codecov.io/gh/batistagroup/calcflow/graph/badge.svg?token=bO5X75J8li)](https://codecov.io/gh/batistagroup/calcflow)
 ![codequal](https://github.com/batistagroup/calcflow/actions/workflows/quality.yml/badge.svg)
 
-**CalcFlow: Quantum Chemistry Calculation I/O. Done Right.**
-
 CalcFlow provides a robust, Pythonic interface for preparing inputs and parsing outputs for quantum chemistry software like Q-Chem and ORCA. It has **zero external dependencies** and is built for clarity and reliability. Get your calculations set up and results processed without the usual boilerplate.
 
-WARNING: Package is in pre-release alpha stage. May introduce backwards-incompatible changes. Contributions & suggestions & advice are welcome.
+> [!WARNING]  
+> Package is in pre-release alpha stage. May introduce backwards-incompatible changes. Contributions & suggestions & advice are welcome.
 
 ## Key Features
 

--- a/src/calcflow/core.py
+++ b/src/calcflow/core.py
@@ -21,7 +21,7 @@ class CalculationInput(ABC):
     Attributes:
         charge (int): Molecular charge.
         spin_multiplicity (int): Spin multiplicity (1 for singlet, 2 for doublet, etc.). Must be a positive integer.
-        task (Literal["energy", "geometry"]): Type of calculation to perform.
+        task (Literal["energy", "geometry", "frequency"]): Type of calculation to perform.
         level_of_theory (str): Electronic structure method/functional (e.g., "B3LYP", "CCSD(T)").
         basis_set (str | dict[str, str]): Basis set to use. Can be a string for standard basis sets
             or a dictionary for program-specific basis set specifications.
@@ -34,7 +34,7 @@ class CalculationInput(ABC):
 
     charge: int
     spin_multiplicity: int
-    task: Literal["energy", "geometry"]
+    task: Literal["energy", "geometry", "frequency"]
     level_of_theory: str
     basis_set: str | dict[str, str]
 

--- a/src/calcflow/inputs/orca.py
+++ b/src/calcflow/inputs/orca.py
@@ -397,11 +397,15 @@ class OrcaInput(CalculationInput):
         keywords.extend(self._handle_level_of_theory())
 
         # Basis set is guaranteed to be str by __post_init__ validation
+        assert isinstance(self.basis_set, str), "basis_set must be str for ORCA (validated in __post_init__)"
         keywords.append(self.basis_set)
 
         if self.ri_approx:
             keywords.append(self.ri_approx)
             # aux_basis is guaranteed to exist and be str when ri_approx is set by __post_init__ validation
+            assert isinstance(self.aux_basis, str), (
+                "aux_basis must be str when ri_approx is set (validated in __post_init__)"
+            )
             keywords.append(self.aux_basis)
 
         if self.implicit_solvation_model:

--- a/src/calcflow/inputs/orca.py
+++ b/src/calcflow/inputs/orca.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, replace
 from typing import ClassVar, Literal, TypeVar, cast, get_args
 
 from calcflow.core import CalculationInput
-from calcflow.exceptions import InputGenerationError, NotSupportedError, ValidationError
+from calcflow.exceptions import NotSupportedError, ValidationError
 from calcflow.geometry.static import Geometry
 from calcflow.utils import logger
 
@@ -43,6 +43,7 @@ class OrcaInput(CalculationInput):
             Defaults to False.
         recalc_hess_freq: Frequency for Hessian recalculation. Defaults to None.
         optimize_hydrogens_only: Flag to optimize only hydrogens in geometry optimization. Defaults to False.
+        run_frequency: Flag to enable frequency calculations in combination with other tasks. Defaults to False.
     """
 
     program: ClassVar[str] = "orca"
@@ -58,6 +59,8 @@ class OrcaInput(CalculationInput):
     tddft_iroot: int | None = None
     tddft_triplets: bool = False
     tddft_use_tda: bool = True
+
+    run_frequency: bool = False
 
     implicit_solvation_model: ORCA_ALLOWED_SOLVATION_MODELS | None = None
     solvent: str | None = None
@@ -139,6 +142,11 @@ class OrcaInput(CalculationInput):
 
         if self.optimize_hydrogens_only and self.task != "geometry":
             raise ValidationError("Optimizing only hydrogens is only applicable for 'geometry' tasks.")
+
+        if self.task == "frequency" and self.run_frequency:
+            raise ValidationError(
+                "Cannot set both task='frequency' and run_frequency=True. Use either task='frequency' for frequency-only calculations or run_frequency=True to combine with other tasks."
+            )
 
     def set_solvation(self: T_OrcaInput, model: str | None, solvent: str | None) -> T_OrcaInput:
         """
@@ -236,6 +244,24 @@ class OrcaInput(CalculationInput):
             tddft_triplets=triplets,
             tddft_use_tda=use_tda,
         )
+
+    def enable_frequency(self: T_OrcaInput) -> T_OrcaInput:
+        """Enable frequency calculations in combination with the current task.
+
+        Returns:
+            A new OrcaInput instance with frequency calculations enabled
+
+        Raises:
+            ValidationError: If the current task is already 'frequency'
+
+        Notes:
+            Use task='frequency' for frequency-only calculations, or this method to combine
+            frequency calculations with geometry optimization or single-point energy.
+        """
+        if self.task == "frequency":
+            raise ValidationError("Task is already 'frequency'. Use task='frequency' for frequency-only calculations.")
+        logger.info(f"Enabling frequency calculations in combination with {self.task} task.")
+        return replace(self, run_frequency=True)
 
     def set_hessian_recalculation(self: T_OrcaInput, frequency: int) -> T_OrcaInput:
         """Enable and configure Hessian recalculation during geometry optimization.
@@ -357,22 +383,21 @@ class OrcaInput(CalculationInput):
             keywords.append("Opt")
         elif self.task == "energy":
             keywords.append("SP")
+        elif self.task == "frequency":
+            keywords.append("Freq")
+
+        if self.run_frequency and self.task != "frequency":
+            keywords.append("Freq")
 
         keywords.extend(self._handle_level_of_theory())
 
-        if isinstance(self.basis_set, str):
-            keywords.append(self.basis_set)
-        elif isinstance(self.basis_set, dict):
-            raise InputGenerationError("Dictionary basis sets require a %basis block, not yet implemented.")
-        else:
-            raise InputGenerationError(f"Unsupported basis_set type: {type(self.basis_set)}")
+        # Basis set is guaranteed to be str by __post_init__ validation
+        keywords.append(self.basis_set)  # type: ignore[arg-type]
 
         if self.ri_approx:
             keywords.append(self.ri_approx)
-            if self.aux_basis:
-                keywords.append(self.aux_basis)
-            else:
-                raise ValidationError("RI approximation specified without auxiliary basis set.")
+            # aux_basis is guaranteed to exist when ri_approx is set by __post_init__ validation
+            keywords.append(self.aux_basis)  # type: ignore[arg-type]
 
         if self.implicit_solvation_model:
             solvent_str = f'("{self.solvent}")' if self.solvent else ""

--- a/tests/inputs/test_orca.py
+++ b/tests/inputs/test_orca.py
@@ -930,42 +930,6 @@ end"""
         assert default_geom.get_coordinate_block().strip() in output
         assert output.strip().endswith("*")
 
-    def test_export_dict_basis_error(self, minimal_orca_input: OrcaInput, default_geom: Geometry) -> None:
-        """Test export raises error for dictionary basis sets."""
-        with pytest.raises(
-            NotSupportedError,
-            match="Dictionary basis sets are not yet fully implemented in export_input_file for ORCA.",
-        ):
-            dict_basis_input = OrcaInput(
-                task="energy",
-                level_of_theory="hf",
-                basis_set={"O": "def2-svp", "H": "sto-3g"},  # type: ignore
-                charge=0,
-                spin_multiplicity=1,
-            )
-            dict_basis_input.export_input_file(default_geom)
-
-    def test_export_unsupported_basis_set_type_error(
-        self, minimal_orca_input: OrcaInput, default_geom: Geometry
-    ) -> None:
-        """Test export raises InputGenerationError for unsupported basis_set types."""
-        from calcflow.exceptions import InputGenerationError
-
-        invalid_basis_input = replace(minimal_orca_input, basis_set=123)  # type: ignore
-        with pytest.raises(InputGenerationError, match="Unsupported basis_set type:"):
-            invalid_basis_input.export_input_file(default_geom)
-
-    def test_export_tddft_validation_error_in_block(
-        self, minimal_orca_input: OrcaInput, default_geom: Geometry
-    ) -> None:
-        """Test ValidationError in _get_tddft_block if inconsistent state is forced."""
-        # Create an inconsistent state *after* __post_init__ validation
-        with pytest.raises(
-            ValidationError, match="If run_tddft is True, either tddft_nroots or tddft_iroot must be specified."
-        ):
-            inconsistent_input = replace(minimal_orca_input, run_tddft=True, tddft_nroots=None, tddft_iroot=None)
-            inconsistent_input.export_input_file(default_geom)  # Should raise in _get_tddft_block (Line 315)
-
     def test_export_geom_recalc_hess(self, minimal_orca_input: OrcaInput, default_geom: Geometry) -> None:
         """Test export with Hessian recalculation enabled."""
         geom_input = replace(minimal_orca_input, task="geometry")

--- a/tests/inputs/test_orca.py
+++ b/tests/inputs/test_orca.py
@@ -344,6 +344,30 @@ class TestOrcaInputInitValidation:
                 run_frequency=True,
             )
 
+    def test_init_invalid_basis_set_type_error(self) -> None:
+        """Test __post_init__ validation fails for non-string basis_set types."""
+        with pytest.raises(ValidationError, match="basis_set must be a string, got"):
+            OrcaInput(
+                task="energy",
+                level_of_theory="hf",
+                basis_set=123,  # type: ignore[arg-type]
+                charge=0,
+                spin_multiplicity=1,
+            )
+
+    def test_init_invalid_aux_basis_type_error(self) -> None:
+        """Test __post_init__ validation fails for non-string aux_basis when ri_approx is set."""
+        with pytest.raises(ValidationError, match="aux_basis must be a string when ri_approx is set, got"):
+            OrcaInput(
+                task="energy",
+                level_of_theory="hf",
+                basis_set="sto-3g",
+                charge=0,
+                spin_multiplicity=1,
+                ri_approx="RIJCOSX",
+                aux_basis=456,  # type: ignore[arg-type]
+            )
+
 
 class TestOrcaInputMethods:
     """Tests for methods modifying OrcaInput instances."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for frequency calculations as a task option.
  - Introduced an option to enable frequency calculations alongside other tasks.
- **Bug Fixes**
  - Improved validation to prevent invalid combinations of task options.
  - Enhanced validation for basis set and auxiliary basis types.
- **Tests**
  - Added comprehensive tests for frequency-related options, validation, and export behavior.
- **Documentation**
  - Added a "Related Works" section comparing this project with other quantum chemistry tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->